### PR TITLE
add news and training links, separate resources from software

### DIFF
--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -6,12 +6,12 @@ subitems:
     url: /eligibility
   - title: Getting started
     url: /projects_allocations
-  - title: Available resources
+  - title: ABLeS resources & how-to Guides
     url: /resources
-  - title: ABLeS Participants
-    url: /participants
-  - title: Shared software and reference data
+  - title: ABLeS software and reference data
     url: /if89
+  - title: ABLeS participants
+    url: /participants
   - title: Acknowledging ABLeS
     url: /acknowledgements
   - title: Help and contact details

--- a/if89.md
+++ b/if89.md
@@ -1,13 +1,35 @@
 ---
-title: Shared repository of tools and software (`project if89` on NCI)
+title: ABLeS available software and reference data
 toc: false
 ---
 
-ABLeS participants have access to the Australian BioCommons Tools and Workflows project, in project allocation if89. This
-is a repository of popular tools, containers and workflows that can be used by anyone in the NCI user group. Anyone
-from an NCI users can contribute to if89 and add more tools that will be shared with others.
+This page provides a comprehensive overview of tools, containers, workflows, and datasets available to ABLeS researchers. It also includes information about the **Australian BioCommons Tools and Workflows project (if89)**, which serves as a shared repository for bioinformatics tools and workflows.
 
-## Software
+### Pawsey Supercomputing Centre
+
+#### Software
+
+There is a wide range of centrally installed software for Setonix users, including popular bioinformatics tools. More information about [software on Setonix](https://support.pawsey.org.au/documentation/display/US/Software+Stack).
+
+Setonix users can also install their choice of software on the `/software` partition. We also encourage usage of containers with Singularity. Users are able to download any containers they like!
+
+#### Reference datasets
+
+Popular bioinformatics [reference datasets](https://support.pawsey.org.au/documentation/display/US/Life+Science+and+Bioinformatics) are available on Pawsey. Additional reference sets can be requested via <help@pawsey.org.au>
+
+### National Computational Infrastructure (NCI)
+
+#### Centrally supported software (`/apps`)
+
+Centrally supported software available through NCI can be viewed [here](https://opus.nci.org.au/display/Help/5.+Software+Applications).
+
+### Shared repository of tools and software (`project if89` on NCI)
+
+Users at NCI also have access to the `Australian BioCommons Tools and Workflows project`, in project allocation `if89`. This is a repository of popular tools, containers and workflows that can be used by anyone in the NCI system.
+
+Anyone from an NCI project is also invited to contribute to `if89`, and add more software installations that can be shared with others.
+
+#### Software
 
 The list of tools available through the Australian BioCommons Shared Tools and Workflows repository (`NCI (if89)`) is available through <a href="https://australianbiocommons.github.io/2_tools.html">ToolFinder</a>.
 
@@ -57,7 +79,7 @@ The list of tools available through the Australian BioCommons Shared Tools and W
 
 <br/>
 
-## Containers
+#### Containers
 
  <div class="accordion" id="accordion-if89-cont">
       <div class="accordion-item">
@@ -76,7 +98,7 @@ The list of tools available through the Australian BioCommons Shared Tools and W
 
 <br/>
 
-## Workflows
+#### Workflows
 
  <div class="accordion" id="accordion-if89-wf">
       <div class="accordion-item">
@@ -95,7 +117,7 @@ The list of tools available through the Australian BioCommons Shared Tools and W
 
 <br/>
 
-## Software databases
+#### Software databases
 
 Some of the databases required by different bioinformatics software tools are made available through the if89 project.  
 They are located at <code>/g/data/if89/data_library</code>. You can request other databases to be included by [contacting us](https://australianbiocommons.github.io/ables/contact-us/).

--- a/index.md
+++ b/index.md
@@ -47,6 +47,75 @@ ABLeS is co-funded by <a href="https://bioplatforms.com/biocommons/">Bioplatform
 
 <br/>
 
+## News from ABLeS
+
+<br/>
+
+<div style="width: 100%; margin: auto;">
+    <div class="container">
+        <ul style="list-style-type: none; padding: 0;">
+            <!-- Blog Post 1 -->
+            <li style="margin-bottom: 20px;">
+                <a href="https://www.biocommons.org.au/news/ciehf" style="text-decoration: none; color: black;">
+                    <h3 style="margin: 0; font-size: 18px; color: #5ac3b1;">Australian palaeoenvironments and biodiversity to be reconstructed through metagenomic analysis of sedimentary ancient DNA by national collaboration with Indigenous partners</h3>
+                </a>
+                <p style="margin: 5px 0 0; font-size: 14px; color: #a0a0a0;">Mar 31, 2025</p>
+            </li>
+            <!-- Blog Post 2 -->
+            <li style="margin-bottom: 20px;">
+                <a href="https://www.biocommons.org.au/news/ables-user-group-meetings" style="text-decoration: none; color: black;">
+                    <h3 style="margin: 0; font-size: 18px; color: #5ac3b1;">Knowledge sharing enABLeS computational research across the life sciences</h3>
+                </a>
+                <p style="margin: 5px 0 0; font-size: 14px; color: #a0a0a0;">Mar 31, 2025</p>
+            </li>
+            <!-- Blog Post 3 -->
+            <li style="margin-bottom: 20px;">
+                <a href="https://www.biocommons.org.au/news/ables-icgrc" style="text-decoration: none; color: black;">
+                    <h3 style="margin: 0; font-size: 18px; color: #5ac3b1;">Supercomputing access powers development of a new multi-omics resource</h3>
+                </a>
+                <p style="margin: 5px 0 0; font-size: 14px; color: #a0a0a0;">Nov 29, 2024</p>
+            </li>
+            <!-- Blog Post 4 -->
+            <li style="margin-bottom: 20px;">
+                <a href="https://www.biocommons.org.au/news/thekids-ables" style="text-decoration: none; color: black;">
+                    <h3 style="margin: 0; font-size: 18px; color: #5ac3b1;">Supercomputing access powers paediatric research</h3>
+                </a>
+                <p style="margin: 5px 0 0; font-size: 14px; color: #a0a0a0;">Aug 29, 2024</p>
+            </li>
+            <!-- Blog Post 5 -->
+            <li style="margin-bottom: 20px;">
+                <a href="https://www.biocommons.org.au/news/deep-sea-ables" style="text-decoration: none; color: black;">
+                    <h3 style="margin: 0; font-size: 18px; color: #5ac3b1;">Latest tech unlocks deep sea mysteries hidden in museum collections</h3>
+                </a>
+                <p style="margin: 5px 0 0; font-size: 14px; color: #a0a0a0;">May 29, 2024</p>
+            </li>
+            <!-- Blog Post 6 -->
+            <li style="margin-bottom: 20px;">
+                <a href="https://www.biocommons.org.au/news/ables-webinar2024" style="text-decoration: none; color: black;">
+                    <h3 style="margin: 0; font-size: 18px; color: #5ac3b1;">Latest tech unlocks deep sea mysteries hidden in museum collections</h3>
+                </a>
+                <p style="margin: 5px 0 0; font-size: 14px; color: #a0a0a0;">Feb 29, 2024</p>
+            </li>
+            <!-- Blog Post 7 -->
+            <li style="margin-bottom: 20px;">
+                <a href="https://www.biocommons.org.au/news/sca2024-wrap" style="text-decoration: none; color: black;">
+                    <h3 style="margin: 0; font-size: 18px; color: #5ac3b1;">Creative collisions: Bio Day a hit at Supercomputing Asia 2024</h3>
+                </a>
+                <p style="margin: 5px 0 0; font-size: 14px; color: #a0a0a0;">Feb 27, 2024</p>
+            </li>
+            <!-- Blog Post 8 -->
+            <li style="margin-bottom: 20px;">
+                <a href="https://www.biocommons.org.au/news/pawsey-access" style="text-decoration: none; color: black;">
+                    <h3 style="margin: 0; font-size: 18px; color: #5ac3b1;">National collaboration advances computing power for bioinformatics</h3>
+                </a>
+                <p style="margin: 5px 0 0; font-size: 14px; color: #a0a0a0;">May 30, 2023</p>
+            </li>
+        </ul>
+    </div>
+</div>
+
+<br/>
+
 {% include affiliation-tiles-selection.html type="infrastructure" %}
 
 

--- a/resources.md
+++ b/resources.md
@@ -1,17 +1,30 @@
 ---
-title: Resources available for ABLeS participants
+title: Resources available for ABLeS participants & how-to Guides
 ---
 
+This page outlines the computational infrastructure, specialist support, and software resources available to ABLeS project teams. Quick links and how-to guides are included to help you make the most of these resources.
 
 ## Computational resources
 
-ABLes computational resources are allocated to each project quarterly and additional resources can be requested by each project's bioinformatics lead.
+ABLeS projects receive compute and storage allocations on both the Pawsey Supercomputing Centre and the National Computational Infrastructure (NCI), reviewed quarterly. Additional resources may be requested by a project’s bioinformatics lead.
 
 {% include callout.html type="note" content="Additional resources can be requested [using this form](https://docs.google.com/forms/d/e/1FAIpQLSe_zrqiE7QSh1FFlmzMxFV6F_u5G-4dnAJ1H7vpN6kkkATyww/viewform?usp=header)." %}
 
 ### Pawsey Supercomputing Centre
 
 ABLeS includes 10 million service units (SUs) of compute capacity on [Setonix](https://pawsey.org.au/systems/setonix/) and flexible storage on the fast S3 based [Acacia](https://pawsey.org.au/systems/acacia/) storage system. These SUs can be utilised across CPU and GPU nodes.
+
+Centrally installed software and popular bioinformatics reference datasets are available on Pawsey. You can find more details **[here](/ables/if89/)**.
+
+#### How-to Guides
+
+<div style="border: 1px solid #a0a0a0; padding: 15px; border-radius: 5px; background-color: #f9f9f9;">
+Pawsey offers a range of in-person and online trainings, workshops, and activities to help you best use Pawsey resources:
+<ul>
+    <li><a href="https://pawsey.atlassian.net/wiki/spaces/US/pages/51917528/User+Training">Pawsey user training</a></li>
+    <li><a href="https://pawsey.atlassian.net/wiki/spaces/US/pages/51925434/Setonix+User+Guide">Setonix user Guide</a></li>
+</ul>
+</div>
 
 ### National Computational Infrastructure (NCI)
 
@@ -22,39 +35,24 @@ Details on:
 - [Gadi HPC resources](https://nci.org.au/our-systems/hpc-systems)
 - [Gadi storage system](https://nci.org.au/our-systems/storage-systems).
 
+Centrally installed software are available on NCI. You can find more details **[here](/ables/if89/)**.
+
+#### How-to Guides
+
+<div style="border: 1px solid #a0a0a0; padding: 15px; border-radius: 5px; background-color: #f9f9f9;">
+NCI provides <a href="https://nci.org.au/users/user-training">training resources and in-person training courses</a> throughout the year to help develop the skills of the NCI user community:
+<ul>
+    <li><a href="https://opus.nci.org.au/display/Help/NCI+Training+and+Educational+Events">Calendar of upcoming training opportunities</a></li>
+    <li><a href="https://opus.nci.org.au/">User Guides</a></li>
+    <li><a href="https://us14.list-manage.com/contact-form?u=591027c2b3f5eea58dacbcbf7&form_id=3ee635103a2d75f56c49b523d762d0fb">Register to become a NCI user</a></li>
+</ul>
+</div>
+
 ## Specialist expertise
 
-ABLeS projects are supported by NCI, Pawsey and ABLeS specialists to install, develop, optimise and deploy tools and workflows.
+ABLeS projects can access expert support from NCI, Pawsey and ABLeS specialists to install, develop, optimise and deploy tools and workflows.
 
-{% include callout.html type="note" content="If you are part of an ABLeS project and need help, please submit a request through [this GoogleForm](https://docs.google.com/forms/d/e/1FAIpQLSere1PvgPEuJkpvQUk1-11C88IAeQNQKEUFc-Qgbn5GgKK2jw/viewform?usp=sf_link)." %}
-
-## Available software and reference data
-
-### Pawsey Supercomputing Centre
-
-#### Software
-
-There is a wide range of centrally installed software for Setonix users, including popular bioinformatics tools. More information about [software on Setonix](https://support.pawsey.org.au/documentation/display/US/Software+Stack).
-
-Setonix users can also install their choice of software on the `/software` partition. We also encourage usage of containers with Singularity. Users are able to download any containers they like!
-
-#### Reference datasets at Pawsey
-
-Popular bioinformatics [reference datasets](https://support.pawsey.org.au/documentation/display/US/Life+Science+and+Bioinformatics) are available on Pawsey. Additional reference sets can be requested via <help@pawsey.org.au>
-
-### National Computational Infrastructure (NCI)
-
-#### Centrally supported software (`/apps`)
-
-Centrally supported software available through NCI can be viewed [here](https://opus.nci.org.au/display/Help/5.+Software+Applications).
-
-#### Shared repository of tools and software
-
-Users at NCI also have access to the `Australian BioCommons Tools and Workflows project`, in project allocation `if89`. This is a repository of popular tools, containers and workflows that can be used by anyone in the NCI system.
-
-Anyone from an NCI project is also invited to contribute to `if89`, and add more software installations that can be shared with others.
-
-Details are available **[here](/ables/if89/)**.
+{% include callout.html type="note" content="If you are part of an ABLeS project and need help, please submit a request through [this Google Form](https://docs.google.com/forms/d/e/1FAIpQLSere1PvgPEuJkpvQUk1-11C88IAeQNQKEUFc-Qgbn5GgKK2jw/viewform?usp=sf_link)." %}
 
 ## Resource summary
 


### PR DESCRIPTION
- ABLeS news are at the bottom of the Home page
- How-to guides for Pawsey and NCI are in the resources page
- the software and reference data sections are merged with the if89 project