### PR TITLE
Add updated kraken2 databases

### DIFF
--- a/if89.md
+++ b/if89.md
@@ -122,7 +122,7 @@ The list of tools available through the Australian BioCommons Shared Tools and W
 Some of the databases required by different bioinformatics software tools are made available through the if89 project.  
 They are located at <code>/g/data/if89/data_library</code>. You can request other databases to be included by [contacting us](https://australianbiocommons.github.io/ables/contact-us/).
 
-A list of the currently available (`as of 25 Jan 2023`) databases is included below:
+A list of the currently available (`as of 25 Aug 2025`) databases is included below:
 
 <div class="accordion" id="accordion-if89-ds">
       <div class="accordion-item">
@@ -221,6 +221,20 @@ A list of the currently available (`as of 25 Jan 2023`) databases is included be
                  <td>Kraken2 pre-built index for RefSeq database (archaea, bacteria, viral, plasmid, human, protozoa & fungi) plus UniVec_Core.
                  </td>
                </tr>
+               <tr>
+                  <td>Kraken2</td>
+                  <td><a href="https://benlangmead.github.io/aws-indexes/k2"> Kraken 2, KrakenUniq and Bracken indexes </a></td>
+                  <td> 9 Jun 2025 </td>
+                  <td><code>kraken2/09062025/k2_core_nt</code></td>
+                  <td>Kraken2 Very large collection, inclusive of GenBank, RefSeq, TPA and PDB.</td>
+                </tr>
+                <tr>
+                  <td>Kraken2</td>
+                  <td><a href="https://benlangmead.github.io/aws-indexes/k2"> Kraken 2, KrakenUniq and Bracken indexes </a></td>
+                  <td> 9 Jun 2025 </td>
+                  <td><code>kraken2/09062025/k2_standard</code></td>
+                  <td>Kraken2 pre-built "standard" database, includes RefSeq archaea, bacteria, viral, plasmid, human, plus UniVec_Core.</td>
+                </tr>
                <tr>
                  <td>Dfam</td>
                  <td><a href="https://www.dfam.org/home"> Dfam </a></td>


### PR DESCRIPTION
Add Kraken2 databases (09062025) to if89 software databases table

This PR updates `if89.md` to include two new Kraken2 database entries:

- `kraken2/09062025/k2_core_nt`  
- `kraken2/09062025/k2_standard`  

These are pre-built Kraken2 indexes (dated 9 June 2025), added to the "Software databases" section so users can easily find and use them.
