### PR TITLE
Adding additional avail data - HomoRef

### DIFF
--- a/if89.md
+++ b/if89.md
@@ -243,6 +243,38 @@ A list of the currently available (`as of 25 Aug 2025`) databases is included be
                  <td>Dfam 3.9; FamDB Format 2.0; Partition 7 [dfam39_full.7.h5]: Mammalia (57 GB) More info - https://www.dfam.org/releases/Dfam_3.9/families/FamDB/README.txt. Available with RepeatMasker/4.2.0 (if89 module)
                  </td>
                </tr>
+               <tr>
+  <td>Human reference genome</td>
+  <td>
+    <a href="https://www.ncbi.nlm.nih.gov/assembly/GCF_000001405.40/">
+      GRCh38.p14
+    </a>
+  </td>
+  <td>Feb 2022</td>
+  <td><code>Homo_Ref/GRCh38.p14</code></td>
+  <td>
+    Homo sapiens reference genome GRCh38 patch release 14 (GCF_000001405.40).
+    Includes primary assembly FASTA, gene annotation (GTF), transcript and protein FASTA files
+    from NCBI RefSeq. This assembly is the current standard reference for WGS/WES alignment,
+    variant calling, and annotation pipelines (e.g. BWA-MEM2, GATK, DeepVariant, VEP).
+  </td>
+</tr>
+               <tr>
+  <td>Human reference genome</td>
+  <td>
+    <a href="https://www.ncbi.nlm.nih.gov/assembly/GCF_000001405.25/">
+      GRCh37.p13
+    </a>
+  </td>
+  <td>Feb 2014</td>
+  <td><code>Homo_Ref/GRCh37.p13</code></td>
+  <td>
+    Homo sapiens reference genome GRCh37 patch release 13 (GCF_000001405.25),
+    maintained for backward compatibility with legacy datasets and resources
+    (e.g. older GWAS, ExAC, early gnomAD releases). Includes primary assembly FASTA,
+    gene annotation (GTF), transcript and protein FASTA files from NCBI RefSeq.
+  </td>
+</tr>
               </tbody>
             </table>
           </div>
@@ -256,4 +288,5 @@ A list of the currently available (`as of 25 Aug 2025`) databases is included be
 ## if89 Contributors
 
 {% include contributor-tiles-all.html custom="Hardip Patel, J King Chang, Ziad Al Bkhetan, Andre Martins Reis, Hasindu Gamaarachchi, Kyle Drover, Tim Amos, Leah Kemp, Kisaru Liyanage, Terry Bertozzi, Javed Shaikh, Kirat Alreja,  Andrey Bliznyuk, Hyungtaek Jung, Wenjing Xue, Farhad Masoomi-Aladizgeh, Haixia Guan, Johan Gustafsson, Dale Roberts" sort=false%}
+
 


### PR DESCRIPTION
Includes human reference database version hg38 and hg19